### PR TITLE
Use long dtype for indexing and stdlib quicksort

### DIFF
--- a/ext/_core.c
+++ b/ext/_core.c
@@ -89,10 +89,10 @@ extern double _get_kernel_size(double *distances, size_t npoints, double fractio
 }
 
 extern void _get_density(double kernel_size, double *distances, size_t npoints, double *density) {
-    size_t i, j, o;
+    size_t i, j;
     double rho;
     for (i = 0; i < npoints - 1; ++i) {
-        o = i * npoints;
+        size_t o = i * npoints;
         for (j = i + 1; j < npoints; ++j) {
             rho = exp(-sqr(distances[o + j] / kernel_size));
             density[i] += rho;

--- a/ext/_core.c
+++ b/ext/_core.c
@@ -16,6 +16,7 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "_core.h"
 
 #include <stdlib.h>
 #include <math.h>
@@ -25,68 +26,54 @@
 ***************************************************************************************************/
 
 #ifdef _MSC_VER
-    /* handle Microsofts C99 incompatibility */
-    #include <float.h>
-    #define INFINITY (DBL_MAX+DBL_MAX)
-    #define NAN (INFINITY-INFINITY)
+/* handle Microsofts C99 incompatibility */
+#include <float.h>
+#define INFINITY (DBL_MAX+DBL_MAX)
+#define NAN (INFINITY-INFINITY)
 #else
-    /* if not available otherwise, define INFINITY/NAN in the GNU style */
-    #ifndef INFINITY
-        #define INFINITY (1.0/0.0)
-    #endif
-    #ifndef NAN
-        #define NAN (INFINITY-INFINITY)
-    #endif
+/* if not available otherwise, define INFINITY/NAN in the GNU style */
+#ifndef INFINITY
+#define INFINITY (1.0/0.0)
+#endif
+#ifndef NAN
+#define NAN (INFINITY-INFINITY)
+#endif
 #endif
 
 /***************************************************************************************************
 *   static convenience functions (without cython wrappers)
 ***************************************************************************************************/
 
-static double sqr(double x)
-{
+static double sqr(double x) {
     return (x == 0.0) ? 0.0 : x * x;
 }
 
-static double distance(double *points, int n, int m, int ndim)
-{
-    int i, o = n * ndim, p = m * ndim;
+static double distance(double *points, size_t n, size_t m, size_t ndim) {
+    size_t i, o = n * ndim, p = m * ndim;
     double sum = 0.0;
-    for(i=0; i<ndim; ++i)
+    for (i = 0; i < ndim; ++i)
         sum += sqr(points[o + i] - points[p + i]);
     return sqrt(sum);
 }
 
-static void mixed_sort(double *array, int L, int R)
-/* mixed_sort() is based on examples from http://www.linux-related.de (2004) */
+static int compare_double(const void * a, const void * b) {
+    return *(double*)a - *(double*)b;
+}
+
+static void mixed_sort(double *array, long L, long R)
 {
-    int l, r;
+    long l, r;
     double swap;
-    if(R - L > 25) /* use quicksort */
+    size_t n = R - L;
+    if (n > 25) /* use quicksort */
     {
-        l = L - 1;
-        r = R;
-        for(;;)
-        {
-            while(array[++l] < array[R]);
-            while((array[--r] > array[R]) && (r > l));
-            if(l >= r) break;
-            swap = array[l];
-            array[l] = array[r];
-            array[r] = swap;
-        }
-        swap = array[l];
-        array[l] = array[R];
-        array[R] = swap;
-        mixed_sort(array, L, l - 1);
-        mixed_sort(array, l + 1, R);
-    }
-    else /* use insertion sort */
+        /* TODO: replacing the old quicksort routine prior this commit breaks all the tests... */
+        qsort(array, n+1, sizeof(double), compare_double);
+    } else /* use insertion sort */
     {
-        for(l=L+1; l<=R; ++l)
-        {
+        for (l = L + 1; l <= R; ++l) {
             swap = array[l];
-            for(r=l-1; (r >= L) && (swap < array[r]); --r)
+            for (r = l - 1; (r >= L) && (swap < array[r]); --r)
                 array[r + 1] = array[r];
             array[r + 1] = swap;
         }
@@ -97,45 +84,37 @@ static void mixed_sort(double *array, int L, int R)
 *   pydpc core functions (with cython wrappers)
 ***************************************************************************************************/
 
-extern void _get_distances(double *points, int npoints, int ndim, double *distances)
-{
-    int i, j, o;
-    for(i=0; i<npoints-1; ++i)
-    {
+extern void _get_distances(double *points, size_t npoints, size_t ndim, double *distances) {
+    size_t i, j, o;
+    for (i = 0; i < npoints - 1; ++i) {
         o = i * npoints;
-        for(j=i+1; j<npoints; ++j)
-        {
+        for (j = i + 1; j < npoints; ++j) {
             distances[o + j] = distance(points, i, j, ndim);
             distances[j * npoints + i] = distances[o + j];
         }
     }
 }
 
-extern double _get_kernel_size(double *distances, int npoints, double fraction)
-{
-    int i, j, o, m = 0, n = (npoints * (npoints - 1)) / 2;
+extern double _get_kernel_size(double *distances, size_t npoints, double fraction) {
+    size_t i, j, o, m = 0, n = (npoints * (npoints - 1)) / 2;
     double kernel_size;
-    double *scratch = (double*) malloc(n * sizeof(double));
-    for(i=0; i<npoints-1; ++i)
-    {
+    double *scratch = (double *) malloc(n * sizeof(double));
+    for (i = 0; i < npoints - 1; ++i) {
         o = i * npoints;
-        for(j=i+1; j<npoints; ++j)
+        for (j = i + 1; j < npoints; ++j)
             scratch[m++] = distances[o + j];
     }
     mixed_sort(scratch, 0, n - 1);
-    kernel_size = scratch[(int) floor(0.5 + fraction * n)];
+    kernel_size = scratch[(size_t) floor(0.5 + fraction * n)];
 
     /* kernel_size is used as a divisor, it can't be zero. Fall back to the first
      * nonzero value. Technically, they *could* all be zero (degenerate case
      * where all points are the same), in which case zero will still be returned.
      * Client code checks for this.
      */
-    if(kernel_size == 0.0)
-    {
-        for(int i = 0; i < n; i++)
-        {
-            if(scratch[i] != 0.0)
-            {
+    if (kernel_size == 0.0) {
+        for (size_t i = 0; i < n; i++) {
+            if (scratch[i] != 0.0) {
                 kernel_size = scratch[i];
                 break;
             }
@@ -146,15 +125,12 @@ extern double _get_kernel_size(double *distances, int npoints, double fraction)
     return kernel_size;
 }
 
-extern void _get_density(double kernel_size, double *distances, int npoints, double *density)
-{
-    int i, j, o;
+extern void _get_density(double kernel_size, double *distances, size_t npoints, double *density) {
+    size_t i, j, o;
     double rho;
-    for(i=0; i<npoints-1; ++i)
-    {
+    for (i = 0; i < npoints - 1; ++i) {
         o = i * npoints;
-        for(j=i+1; j<npoints; ++j)
-        {
+        for (j = i + 1; j < npoints; ++j) {
             rho = exp(-sqr(distances[o + j] / kernel_size));
             density[i] += rho;
             density[j] += rho;
@@ -163,23 +139,18 @@ extern void _get_density(double kernel_size, double *distances, int npoints, dou
 }
 
 extern void _get_delta_and_neighbour(
-    double max_distance, double *distances, int *order, int npoints, double *delta, int *neighbour)
-{
-    int i, j, o;
+        double max_distance, double *distances, size_t *order, size_t npoints, double *delta, size_t *neighbour) {
+    size_t i, j, o;
     double max_delta = 0.0;
-    for(i=0; i<npoints; ++i)
-    {
+    for (i = 0; i < npoints; ++i) {
         delta[order[i]] = max_distance;
         neighbour[i] = -1;
     }
     delta[order[0]] = -1.0;
-    for(i=1; i<npoints; ++i)
-    {
+    for (i = 1; i < npoints; ++i) {
         o = order[i] * npoints;
-        for(j=0; j<i; ++j)
-        {
-            if(distances[o + order[j]] < delta[order[i]])
-            {
+        for (j = 0; j < i; ++j) {
+            if (distances[o + order[j]] < delta[order[i]]) {
                 delta[order[i]] = distances[o + order[j]];
                 neighbour[order[i]] = order[j];
             }
@@ -190,56 +161,46 @@ extern void _get_delta_and_neighbour(
 }
 
 extern void _get_membership(
-    int *clusters, int nclusters, int *order, int *neighbour, int npoints, int *membership)
-{
-    int i;
-    for(i=0; i<npoints; ++i)
+        size_t *clusters, size_t nclusters, size_t *order, size_t *neighbour, size_t npoints, long *membership) {
+    size_t i;
+    for (i = 0; i < npoints; ++i)
         membership[i] = -1;
-    for(i=0; i<nclusters; ++i)
+    for (i = 0; i < nclusters; ++i)
         membership[clusters[i]] = i;
-    for(i=0; i<npoints; ++i)
-    {
-        if(membership[order[i]] == -1)
+    for (i = 0; i < npoints; ++i) {
+        if (membership[order[i]] == - 1)
             membership[order[i]] = membership[neighbour[order[i]]];
     }
 }
 
 extern void _get_border(
-    double kernel_size, double *distances, double *density, int *membership, int npoints,
-    int *border_member, double *border_density)
-{
-    int i, j, o;
+        double kernel_size, double *distances, double *density, long *membership, size_t npoints,
+        bool *border_member, double *border_density) {
+    size_t i, j, o;
     double average_density;
-    for(i=0; i<npoints-1; ++i)
-    {
+    for (i = 0; i < npoints - 1; ++i) {
         o = i * npoints;
-        for(j=i+1; j<npoints; ++j)
-        {
-            if((membership[i] != membership[j]) && (distances[o + j] < kernel_size))
-            {
+        for (j = i + 1; j < npoints; ++j) {
+            if ((membership[i] != membership[j]) && (distances[o + j] < kernel_size)) {
                 average_density = 0.5 * (density[i] + density[j]);
-                if(border_density[membership[i]] < average_density)
+                if (border_density[membership[i]] < average_density)
                     border_density[membership[i]] = average_density;
-                if(border_density[membership[j]] < average_density)
+                if (border_density[membership[j]] < average_density)
                     border_density[membership[j]] = average_density;
-                border_member[i] = 1;
-                border_member[j] = 1;
+                border_member[i] = true;
+                border_member[j] = true;
             }
         }
     }
 }
 
 extern void _get_halo(
-    int border_only, double *border_density,
-    double *density, int *membership, int *border_member, int npoints, int *halo)
-{
-    int i;
-    for(i=0; i<npoints; ++i)
-    {
-        if(density[i] < border_density[membership[i]])
-        {
-            if((0 == border_only) || (1 == border_member[i]))
-                halo[i] = -1;
+        bool border_only, double *border_density,
+        double *density, long *membership, bool *border_member, size_t npoints, int *halo) {
+    size_t i;
+    for (i = 0; i < npoints; ++i) {
+        if (density[i] < border_density[membership[i]] && (border_only || !border_member[i])) {
+            halo[i] = -1;
         }
     }
 }

--- a/ext/_core.c
+++ b/ext/_core.c
@@ -48,9 +48,9 @@ static int compare_double(const void * a, const void * b) {
 ***************************************************************************************************/
 
 extern void _get_distances(double *points, size_t npoints, size_t ndim, double *distances) {
-    size_t i, j, o;
+    size_t i, j;
     for (i = 0; i < npoints - 1; ++i) {
-        o = i * npoints;
+        size_t o = i * npoints;
         for (j = i + 1; j < npoints; ++j) {
             distances[o + j] = distance(points, i, j, ndim);
             distances[j * npoints + i] = distances[o + j];
@@ -59,11 +59,11 @@ extern void _get_distances(double *points, size_t npoints, size_t ndim, double *
 }
 
 extern double _get_kernel_size(double *distances, size_t npoints, double fraction) {
-    size_t i, j, o, m = 0, n = (npoints * (npoints - 1)) / 2;
+    size_t i, j, m = 0, n = (npoints * (npoints - 1)) / 2;
     double kernel_size;
     double *scratch = (double *) malloc(n * sizeof(double));
     for (i = 0; i < npoints - 1; ++i) {
-        o = i * npoints;
+        size_t o = i * npoints;
         for (j = i + 1; j < npoints; ++j)
             scratch[m++] = distances[o + j];
     }

--- a/ext/_core.h
+++ b/ext/_core.h
@@ -26,9 +26,9 @@ extern void _get_distances(double *points, size_t npoints, size_t ndim, double *
 extern double _get_kernel_size(double *distances, size_t npoints, double fraction);
 extern void _get_density(double kernel_size, double *distances, size_t npoints, double *density);
 extern void _get_delta_and_neighbour(
-    double max_distance, double *distances, size_t *order, size_t npoints, double *delta, size_t *neighbour);
+    double max_distance, double *distances, size_t *order, size_t npoints, double *delta, long *neighbour);
 extern void _get_membership(
-    size_t *clusters, size_t nclusters, size_t *order, size_t *neighbour, size_t npoints, long *membership);
+    size_t *clusters, size_t nclusters, size_t *order, long *neighbour, size_t npoints, long *membership);
 extern void _get_border(
     double kernel_size, double *distances, double *density, long *membership, size_t npoints,
     bool *border_member, double *border_density);

--- a/ext/_core.h
+++ b/ext/_core.h
@@ -19,19 +19,21 @@
 
 #ifndef PYDPC_HEADER
 #define PYDPC_HEADER
+#include <stdbool.h>
+#include <stddef.h>
 
-extern void _get_distances(double *points, int npoints, int ndim, double *distances);
-extern double _get_kernel_size(double *distances, int npoints, double fraction);
-extern void _get_density(double kernel_size, double *distances, int npoints, double *density);
+extern void _get_distances(double *points, size_t npoints, size_t ndim, double *distances);
+extern double _get_kernel_size(double *distances, size_t npoints, double fraction);
+extern void _get_density(double kernel_size, double *distances, size_t npoints, double *density);
 extern void _get_delta_and_neighbour(
-    double max_distance, double *distances, int *order, int npoints, double *delta, int *neighbour);
+    double max_distance, double *distances, size_t *order, size_t npoints, double *delta, size_t *neighbour);
 extern void _get_membership(
-    int *clusters, int nclusters, int *order, int *neighbour, int npoints, int *membership);
+    size_t *clusters, size_t nclusters, size_t *order, size_t *neighbour, size_t npoints, long *membership);
 extern void _get_border(
-    double kernel_size, double *distances, double *density, int *membership, int npoints,
-    int *border_member, double *border_density);
+    double kernel_size, double *distances, double *density, long *membership, size_t npoints,
+    bool *border_member, double *border_density);
 extern void _get_halo(
-    int border_only, double *border_density,
-    double *density, int *membership, int *border_member, int npoints, int *halo);
+    bool border_only, double *border_density,
+    double *density, long *membership, bool *border_member, size_t npoints, int *halo);
 
 #endif

--- a/ext/core.pyx
+++ b/ext/core.pyx
@@ -25,9 +25,9 @@ cdef extern from "_core.h":
     void _get_density(double kernel_size, double *distances, size_t npoints, double *density)
     void _get_delta_and_neighbour(
         double max_distance, double *distances, size_t *order,
-        size_t npoints, double *delta, size_t *neighbour)
+        size_t npoints, double *delta, long *neighbour)
     void _get_membership(
-        size_t *clusters, size_t nclusters, size_t *order, size_t *neighbour, size_t npoints, long *membership)
+        size_t *clusters, size_t nclusters, size_t *order, long *neighbour, size_t npoints, long *membership)
     void _get_border(
         double kernel_size, double *distances, double *density, long *membership, size_t npoints,
         bool *border_member, double *border_density)
@@ -49,8 +49,8 @@ def get_kernel_size(np.ndarray[double, ndim=2, mode="c"] distances not None, fra
     return _get_kernel_size(<double*> np.PyArray_DATA(distances), distances.shape[0], fraction)
 
 def get_density(np.ndarray[double, ndim=2, mode="c"] distances not None, kernel_size):
-    npoints = distances.shape[0]
-    density = np.zeros(shape=(npoints,), dtype=np.float64)
+    npoints = len(distances)
+    density = np.zeros(npoints, dtype=np.float64)
     _get_density(
         kernel_size,
         <double*> np.PyArray_DATA(distances),
@@ -62,29 +62,29 @@ def get_delta_and_neighbour(
     np.ndarray[size_t, ndim=1, mode="c"] order not None,
     np.ndarray[double, ndim=2, mode="c"] distances not None,
     max_distance):
-    npoints = distances.shape[0]
-    delta = np.zeros(shape=(npoints,), dtype=np.float64)
-    neighbour = np.zeros(shape=(npoints,), dtype=np.uint)
+    npoints = len(distances)
+    delta = np.zeros(npoints, dtype=np.float64)
+    neighbour = np.empty(npoints, dtype=np.int64)
     _get_delta_and_neighbour(
         max_distance,
         <double*> np.PyArray_DATA(distances),
         <size_t*> np.PyArray_DATA(order),
         npoints,
         <double*> np.PyArray_DATA(delta),
-        <size_t*> np.PyArray_DATA(neighbour))
+        <long*> np.PyArray_DATA(neighbour))
     return delta, neighbour
 
 def get_membership(
     np.ndarray[size_t, ndim=1, mode="c"] clusters not None,
     np.ndarray[size_t, ndim=1, mode="c"] order not None,
-    np.ndarray[size_t, ndim=1, mode="c"] neighbour not None):
+    np.ndarray[long, ndim=1, mode="c"] neighbour not None):
     npoints = order.shape[0]
-    membership = np.zeros(shape=(npoints,), dtype=np.int_)
+    membership = np.zeros(npoints, dtype=long)
     _get_membership(
         <size_t*> np.PyArray_DATA(clusters),
         clusters.shape[0],
         <size_t*> np.PyArray_DATA(order),
-        <size_t*> np.PyArray_DATA(neighbour),
+        <long*> np.PyArray_DATA(neighbour),
         npoints,
         <long*> np.PyArray_DATA(membership))
     return membership

--- a/ext/core.pyx
+++ b/ext/core.pyx
@@ -15,116 +15,114 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as _np
-cimport numpy as _np
+import numpy as np
+cimport numpy as np
+from libcpp cimport bool
 
 cdef extern from "_core.h":
-    void _get_distances(double *points, int npoints, int ndim, double *distances)
-    double _get_kernel_size(double *distances, int npoints, double fraction)
-    void _get_density(double kernel_size, double *distances, int npoints, double *density)
+    void _get_distances(double *points, size_t npoints, size_t ndim, double *distances)
+    double _get_kernel_size(double *distances, size_t npoints, double fraction)
+    void _get_density(double kernel_size, double *distances, size_t npoints, double *density)
     void _get_delta_and_neighbour(
-        double max_distance, double *distances, int *order,
-        int npoints, double *delta, int *neighbour)
+        double max_distance, double *distances, size_t *order,
+        size_t npoints, double *delta, size_t *neighbour)
     void _get_membership(
-        int *clusters, int nclusters, int *order, int *neighbour, int npoints, int *membership)
+        size_t *clusters, size_t nclusters, size_t *order, size_t *neighbour, size_t npoints, long *membership)
     void _get_border(
-        double kernel_size, double *distances, double *density, int *membership, int npoints,
-        int *border_member, double *border_density)
+        double kernel_size, double *distances, double *density, long *membership, size_t npoints,
+        bool *border_member, double *border_density)
     void _get_halo(
-        int border_only, double *border_density,
-        double *density, int *membership, int *border_member, int npoints, int *halo)
+        bool border_only, double *border_density,
+        double *density, long *membership, bool *border_member, size_t npoints, int *halo)
 
-def get_distances(_np.ndarray[double, ndim=2, mode="c"] points not None):
+def get_distances(np.ndarray[double, ndim=2, mode="c"] points not None):
     npoints = points.shape[0]
     ndim = points.shape[1]
-    distances = _np.zeros(shape=(npoints, npoints), dtype=_np.float64)
+    distances = np.zeros(shape=(npoints, npoints), dtype=np.float64)
     _get_distances(
-        <double*> _np.PyArray_DATA(points),
+        <double*> np.PyArray_DATA(points),
         npoints, ndim,
-        <double*> _np.PyArray_DATA(distances))
+        <double*> np.PyArray_DATA(distances))
     return distances
 
-def get_kernel_size(_np.ndarray[double, ndim=2, mode="c"] distances not None, fraction):
-    return _get_kernel_size(<double*> _np.PyArray_DATA(distances), distances.shape[0], fraction)
+def get_kernel_size(np.ndarray[double, ndim=2, mode="c"] distances not None, fraction):
+    return _get_kernel_size(<double*> np.PyArray_DATA(distances), distances.shape[0], fraction)
 
-def get_density(_np.ndarray[double, ndim=2, mode="c"] distances not None, kernel_size):
+def get_density(np.ndarray[double, ndim=2, mode="c"] distances not None, kernel_size):
     npoints = distances.shape[0]
-    density = _np.zeros(shape=(npoints,), dtype=_np.float64)
+    density = np.zeros(shape=(npoints,), dtype=np.float64)
     _get_density(
         kernel_size,
-        <double*> _np.PyArray_DATA(distances),
+        <double*> np.PyArray_DATA(distances),
         npoints,
-        <double*> _np.PyArray_DATA(density))
+        <double*> np.PyArray_DATA(density))
     return density
 
 def get_delta_and_neighbour(
-    _np.ndarray[int, ndim=1, mode="c"] order not None,
-    _np.ndarray[double, ndim=2, mode="c"] distances not None,
+    np.ndarray[size_t, ndim=1, mode="c"] order not None,
+    np.ndarray[double, ndim=2, mode="c"] distances not None,
     max_distance):
     npoints = distances.shape[0]
-    delta = _np.zeros(shape=(npoints,), dtype=_np.float64)
-    neighbour = _np.zeros(shape=(npoints,), dtype=_np.intc)
+    delta = np.zeros(shape=(npoints,), dtype=np.float64)
+    neighbour = np.zeros(shape=(npoints,), dtype=np.uint)
     _get_delta_and_neighbour(
         max_distance,
-        <double*> _np.PyArray_DATA(distances),
-        <int*> _np.PyArray_DATA(order),
+        <double*> np.PyArray_DATA(distances),
+        <size_t*> np.PyArray_DATA(order),
         npoints,
-        <double*> _np.PyArray_DATA(delta),
-        <int*> _np.PyArray_DATA(neighbour))
+        <double*> np.PyArray_DATA(delta),
+        <size_t*> np.PyArray_DATA(neighbour))
     return delta, neighbour
 
 def get_membership(
-    _np.ndarray[int, ndim=1, mode="c"] clusters not None,
-    _np.ndarray[int, ndim=1, mode="c"] order not None,
-    _np.ndarray[int, ndim=1, mode="c"] neighbour not None):
+    np.ndarray[size_t, ndim=1, mode="c"] clusters not None,
+    np.ndarray[size_t, ndim=1, mode="c"] order not None,
+    np.ndarray[size_t, ndim=1, mode="c"] neighbour not None):
     npoints = order.shape[0]
-    membership = _np.zeros(shape=(npoints,), dtype=_np.intc)
+    membership = np.zeros(shape=(npoints,), dtype=np.int_)
     _get_membership(
-        <int*> _np.PyArray_DATA(clusters),
+        <size_t*> np.PyArray_DATA(clusters),
         clusters.shape[0],
-        <int*> _np.PyArray_DATA(order),
-        <int*> _np.PyArray_DATA(neighbour),
+        <size_t*> np.PyArray_DATA(order),
+        <size_t*> np.PyArray_DATA(neighbour),
         npoints,
-        <int*> _np.PyArray_DATA(membership))
+        <long*> np.PyArray_DATA(membership))
     return membership
 
 def get_border(
     kernel_size,
-    _np.ndarray[double, ndim=2, mode="c"] distances not None,
-    _np.ndarray[double, ndim=1, mode="c"] density not None,
-    _np.ndarray[int, ndim=1, mode="c"] membership not None,
+    np.ndarray[double, ndim=2, mode="c"] distances not None,
+    np.ndarray[double, ndim=1, mode="c"] density not None,
+    np.ndarray[long, ndim=1, mode="c"] membership not None,
     nclusters):
     npoints = distances.shape[0]
-    border_density = _np.zeros(shape=(nclusters,), dtype=_np.float64)
-    border_member = _np.zeros(shape=(npoints,), dtype=_np.intc)
+    border_density = np.zeros(nclusters, dtype=np.float64)
+    border_member = np.zeros(npoints, dtype=np.bool)
     _get_border(
         kernel_size,
-        <double*> _np.PyArray_DATA(distances),
-        <double*> _np.PyArray_DATA(density),
-        <int*> _np.PyArray_DATA(membership),
+        <double*> np.PyArray_DATA(distances),
+        <double*> np.PyArray_DATA(density),
+        <long*> np.PyArray_DATA(membership),
         npoints,
-        <int*> _np.PyArray_DATA(border_member),
-        <double*> _np.PyArray_DATA(border_density))
-    return border_density, border_member.astype(_np.bool)
+        <bool*> np.PyArray_DATA(border_member),
+        <double*> np.PyArray_DATA(border_density))
+    return border_density, border_member
 
 def get_halo(
-    _np.ndarray[double, ndim=1, mode="c"] density not None,
-    _np.ndarray[int, ndim=1, mode="c"] membership not None,
-    _np.ndarray[double, ndim=1, mode="c"] border_density not None,
-    _np.ndarray[int, ndim=1, mode="c"] border_member not None,
+    np.ndarray[double, ndim=1, mode="c"] density not None,
+    np.ndarray[long, ndim=1, mode="c"] membership not None,
+    np.ndarray[double, ndim=1, mode="c"] border_density not None,
+    np.ndarray[bool, ndim=1, mode="c"] border_member not None,
     border_only=False):
-    halo = membership.copy()
-    flag = 0
-    if border_only:
-        flag = 1
+    halo = membership.astype(np.int32, copy=True)
     _get_halo(
-        flag,
-        <double*> _np.PyArray_DATA(border_density),
-        <double*> _np.PyArray_DATA(density),
-        <int*> _np.PyArray_DATA(membership),
-        <int*> _np.PyArray_DATA(border_member),
+        border_only,
+        <double*> np.PyArray_DATA(border_density),
+        <double*> np.PyArray_DATA(density),
+        <long*> np.PyArray_DATA(membership),
+        <bool*> np.PyArray_DATA(border_member),
         density.shape[0],
-        <int*> _np.PyArray_DATA(halo))
-    halo_idx = _np.where(halo == -1)[0].astype(_np.intc)
-    core_idx = _np.where(halo != -1)[0].astype(_np.intc)
+        <int*> np.PyArray_DATA(halo))
+    halo_idx = np.where(halo == -1)[0].astype(np.uint)
+    core_idx = np.where(halo != -1)[0].astype(np.uint)
     return halo_idx, core_idx

--- a/pydpc/_reference.py
+++ b/pydpc/_reference.py
@@ -94,7 +94,8 @@ class Cluster(object):
             _np.where(self.delta > self.min_delta)[0], assume_unique=True)
         self.ncl = self.clusters.shape[0]
     def _get_membership(self):
-        self.membership = -1 * _np.ones(shape=self.order.shape, dtype=_np.intc)
+        self.membership = _np.empty_like(self.order, dtype=_np.int_)
+        self.membership[:] = -1
         for i in range(self.ncl):
             self.membership[self.clusters[i]] = i
         for i in range(self.npoints):

--- a/pydpc/dpc.py
+++ b/pydpc/dpc.py
@@ -25,7 +25,7 @@ __all__ = ['Cluster']
 class Distances(object):
     def __init__(self, points, distances=None):
         self.points = points
-        self.npoints = self.points.shape[0]
+        self.npoints = len(self.points)
 
         if distances is None:
             self.distances = _core.get_distances(self.points)
@@ -88,8 +88,6 @@ class Cluster(Graph):
         if self.autoplot:
             self.draw_decision_graph(self.min_density, self.min_delta)
         self._get_cluster_indices()
-        #if not self.nclusters:
-        #    raise RuntimeError('input parameters did not yield any cluster!? wtf')
         self.membership = _core.get_membership(self.clusters, self.order, self.neighbour)
         self.border_density, self.border_member = _core.get_border(
             self.kernel_size, self.distances, self.density, self.membership, self.nclusters)

--- a/pydpc/dpc.py
+++ b/pydpc/dpc.py
@@ -53,9 +53,10 @@ class Density(Distances):
 class Graph(Density):
     def __init__(self, points, fraction, **kwargs):
         super(Graph, self).__init__(points, fraction, **kwargs)
-        self.order = _np.ascontiguousarray(_np.argsort(self.density).astype(_np.intc)[::-1])
+        self.order = _np.ascontiguousarray(_np.argsort(self.density).astype(_np.uint)[::-1])
         self.delta, self.neighbour = _core.get_delta_and_neighbour(
             self.order, self.distances, self.max_distance)
+
 
 class Cluster(Graph):
     def __init__(self, points, fraction=0.02, autoplot=True, **kwargs):
@@ -87,9 +88,9 @@ class Cluster(Graph):
             self.kernel_size, self.distances, self.density, self.membership, self.nclusters)
         self.halo_idx, self.core_idx = _core.get_halo(
             self.density, self.membership,
-            self.border_density, self.border_member.astype(_np.intc), border_only=border_only)
+            self.border_density, self.border_member, border_only=border_only)
     def _get_cluster_indices(self):
         self.clusters = _np.intersect1d(
             _np.where(self.density > self.min_density)[0],
-            _np.where(self.delta > self.min_delta)[0], assume_unique=True).astype(_np.intc)
+            _np.where(self.delta > self.min_delta)[0], assume_unique=True).astype(_np.uint)
         self.nclusters = self.clusters.shape[0]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@
 from setuptools import setup, Extension
 import versioneer
 
+
 def extensions():
     from numpy import get_include
     from Cython.Build import cythonize
@@ -44,11 +45,11 @@ class lazy_cythonize(list):
     def __getitem__(self, ii): return self.c_list()[ii]
     def __len__(self): return len(self.c_list())
 
-def long_description():
-    ld = "Clustering by fast search and find of density peaks, designed by Alex Rodriguez"
-    ld += " and Alessandro Laio, is a density-peak-based clustering algorithm. The pydpc package"
-    ld += " aims to make this algorithm available for Python users."
-    return ld
+
+long_description = """Clustering by fast search and find of density peaks, designed by Alex Rodriguez"
+    and Alessandro Laio, is a density-peak-based clustering algorithm. The pydpc package"
+    aims to make this algorithm available for Python users."
+    """
 
 setup(
     cmdclass=versioneer.get_cmdclass(),
@@ -56,9 +57,9 @@ setup(
     name='pydpc',
     version=versioneer.get_version(),
     description='Python package for Density Peak-based Clustering',
-    long_description=long_description(),
+    long_description=long_description,
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 3 - Beta',
         'Environment :: Console',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
@@ -84,15 +85,10 @@ setup(
     setup_requires=[
         'numpy>=1.7',
         'cython>=0.20',
-        'setuptools>=0.6'],
-    tests_require=[
-        'numpy>=1.7',
-        'nose>=1.3'],
+    ],
     install_requires=[
         'numpy>=1.7',
         'matplotlib'],
     packages=['pydpc'],
-    test_suite='nose.collector',
-    scripts=[]
 )
 

--- a/test/test_consistency.py
+++ b/test/test_consistency.py
@@ -19,54 +19,68 @@ from pydpc._reference import Cluster as Ref
 from pydpc import Cluster
 import numpy as np
 from numpy.testing import assert_array_equal, assert_almost_equal
+import unittest
 
-class TestFourGaussians2D(object):
+
+class TestFourGaussians2D(unittest.TestCase):
+
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         # data generation
+        #state = np.random.RandomState(23215)
+        state = np.random.RandomState(23215)
         cls.npoints = 1000
         cls.mux = 1.8
         cls.muy = 1.8
         cls.fraction = 0.02
         cls.points = np.zeros(shape=(cls.npoints, 2), dtype=np.float64)
-        cls.points[:, 0] = np.random.randn(cls.npoints) + \
-            cls.mux * (-1)**np.random.randint(0, high=2, size=cls.npoints)
-        cls.points[:, 1] = np.random.randn(cls.npoints) + \
-            cls.muy * (-1)**np.random.randint(0, high=2, size=cls.npoints)
+        cls.points[:, 0] = state.randn(cls.npoints) + \
+                           cls.mux * (-1) ** state.randint(0, high=2, size=cls.npoints)
+        cls.points[:, 1] = state.randn(cls.npoints) + \
+                           cls.muy * (-1) ** state.randint(0, high=2, size=cls.npoints)
         # cluster initialisation
         cls.ref = Ref(cls.fraction, autoplot=False)
         cls.ref.load(cls.points)
         cls.ref.assign(20, 1.5)
         cls.dpc = Cluster(cls.points, cls.fraction, autoplot=False)
         cls.dpc.assign(20, 1.5)
-    @classmethod
-    def teardown_class(cls):
-        pass
-    def setup(self):
-        pass
-    def teardown(self):
-        pass
+
     def test_distances(self):
         assert_almost_equal(self.dpc.distances, self.ref.distances, decimal=10)
+
     def test_distances(self):
         assert_almost_equal(self.dpc.kernel_size, self.ref.kernel_size, decimal=10)
+
     def test_density(self):
         assert_almost_equal(self.dpc.density, self.ref.density, decimal=10)
+
     def test_order(self):
         assert_array_equal(self.dpc.order, self.ref.order)
+
     def test_delta(self):
         assert_almost_equal(self.dpc.delta, self.ref.delta, decimal=10)
+
     def test_neighbour(self):
         assert_array_equal(self.dpc.neighbour, self.ref.neighbour)
+
     def test_clusters(self):
         assert_array_equal(self.dpc.clusters, self.ref.clusters)
+
     def test_membership(self):
         assert_array_equal(self.dpc.membership, self.ref.membership)
+
     def test_border_density(self):
         assert_almost_equal(self.dpc.border_density, self.ref.border_density, decimal=10)
+
     def test_border_member(self):
         assert_array_equal(self.dpc.border_member, self.ref.border_member)
+
     def test_halo_idx(self):
         assert_array_equal(self.dpc.halo_idx, self.ref.halo_idx)
+
     def test_core_idx(self):
         assert_array_equal(self.dpc.core_idx, self.ref.core_idx)
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/test/test_consistency.py
+++ b/test/test_consistency.py
@@ -28,7 +28,7 @@ class TestFourGaussians2D(unittest.TestCase):
     def setUpClass(cls):
         # data generation
         #state = np.random.RandomState(23215)
-        state = np.random.RandomState(23215)
+        state = np.random.RandomState()
         cls.npoints = 1000
         cls.mux = 1.8
         cls.muy = 1.8
@@ -82,5 +82,4 @@ class TestFourGaussians2D(unittest.TestCase):
         assert_array_equal(self.dpc.core_idx, self.ref.core_idx)
 
 if __name__ == '__main__':
-    import unittest
     unittest.main()

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -48,7 +48,7 @@ class TestFourGaussians2D(unittest.TestCase):
     def test_neighbour(self):
         assert_array_less(-2, self.dpc.neighbour)
         assert_array_less(self.dpc.neighbour, self.npoints)
-        assert (self.dpc.neighbour == -1).sum() == 1
+        self.assertEqual((self.dpc.neighbour == -1).sum(), 1)
 
     def test_clusters(self):
         assert_array_less(-2, self.dpc.clusters)

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -14,51 +14,58 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
 
-from pydpc import Cluster
 import numpy as np
-from nose.tools import assert_true
 from numpy.testing import assert_array_less
 
-class TestFourGaussians2D(object):
+from pydpc import Cluster
+
+
+class TestFourGaussians2D(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         # data generation
+        state = np.random.RandomState(1131325452)
+        state = np.random.RandomState(0)
         cls.npoints = 1000
         cls.mux = 1.8
         cls.muy = 1.8
         cls.fraction = 0.02
-        cls.points = np.zeros(shape=(cls.npoints, 2), dtype=np.float64)
-        cls.points[:, 0] = np.random.randn(cls.npoints) + \
-            cls.mux * (-1)**np.random.randint(0, high=2, size=cls.npoints)
-        cls.points[:, 1] = np.random.randn(cls.npoints) + \
-            cls.muy * (-1)**np.random.randint(0, high=2, size=cls.npoints)
+        cls.points = np.empty(shape=(cls.npoints, 2), dtype=np.float64)
+        cls.points[:, 0] = state.randn(cls.npoints) + \
+                           cls.mux * (-1) ** state.randint(0, high=2, size=cls.npoints)
+        cls.points[:, 1] = state.randn(cls.npoints) + \
+                       cls.muy * (-1) ** state.randint(0, high=2, size=cls.npoints)
         # cluster initialisation
         cls.dpc = Cluster(cls.points, cls.fraction, autoplot=False)
         cls.dpc.assign(20, 1.5)
-    @classmethod
-    def teardown_class(cls):
-        pass
-    def setup(self):
-        pass
-    def teardown(self):
-        pass
+
     def test_order(self):
         assert_array_less(-1, self.dpc.order)
         assert_array_less(self.dpc.order, self.npoints)
+
     def test_neighbour(self):
         assert_array_less(-2, self.dpc.neighbour)
         assert_array_less(self.dpc.neighbour, self.npoints)
-        assert_true((self.dpc.neighbour == -1).sum() == 1)
+        assert (self.dpc.neighbour == -1).sum() == 1
+
     def test_clusters(self):
         assert_array_less(-2, self.dpc.clusters)
         assert_array_less(self.dpc.clusters, self.npoints)
+
     def test_membership(self):
         assert_array_less(-1, self.dpc.membership)
         assert_array_less(self.dpc.membership, self.dpc.nclusters)
+
     def test_halo_idx(self):
         assert_array_less(-1, self.dpc.halo_idx)
         assert_array_less(self.dpc.halo_idx, self.npoints)
+
     def test_core_idx(self):
         assert_array_less(-1, self.dpc.core_idx)
         assert_array_less(self.dpc.core_idx, self.npoints)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Probably fixes #8 by replacing int based indexing (2**32 -1 points) via long. Also used bool wherever possible to make code more readable (also pep8 and reformatted c code a bit). The mixed sort routine has been replaced in favor of the stdlib impl of quick sort (which is likely more optimized).