### PR TITLE
Fix two long-standing crash bugs (GH-8, GH-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped copyright years and removed package metadata (`__author__`,
   `__email__`, `__license__`, `__copyright__`) that duplicated `pyproject.toml`
 
+### Fixed
+
+- `Cluster.assign` now raises a clear `ValueError` instead of passing empty
+  clusters into the C extension, which could previously segfault (GH-8)
+
 ## [0.2.0] - 2026-07-01
 
 First beta release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Cluster.assign` now raises a clear `ValueError` instead of passing empty
   clusters into the C extension, which could previously segfault (GH-8)
+- Widened 32-bit index/size arithmetic in the C extension to 64 bits,
+  fixing a crash on datasets with roughly 46,000+ points caused by integer
+  overflow, not by memory exhaustion (GH-6)
 
 ## [0.2.0] - 2026-07-01
 

--- a/ext/_core.c
+++ b/ext/_core.c
@@ -17,6 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
 
@@ -57,10 +58,10 @@ static double distance(double *points, int n, int m, int ndim)
     return sqrt(sum);
 }
 
-static void mixed_sort(double *array, int L, int R)
+static void mixed_sort(double *array, int64_t L, int64_t R)
 /* mixed_sort() is based on examples from http://www.linux-related.de (2004) */
 {
-    int l, r;
+    int64_t l, r;
     double swap;
     if(R - L > 25) /* use quicksort */
     {
@@ -99,13 +100,15 @@ static void mixed_sort(double *array, int L, int R)
 
 extern void _get_distances(double *points, int npoints, int ndim, double *distances)
 {
-    int i, j, o;
+    /* i, j, o are widened to 64 bits: for npoints above ~46,000, i * npoints
+     * overflows a 32-bit int, corrupting the flat index into `distances`. */
+    int64_t i, j, o;
     for(i=0; i<npoints-1; ++i)
     {
         o = i * npoints;
         for(j=i+1; j<npoints; ++j)
         {
-            distances[o + j] = distance(points, i, j, ndim);
+            distances[o + j] = distance(points, (int) i, (int) j, ndim);
             distances[j * npoints + i] = distances[o + j];
         }
     }
@@ -113,7 +116,11 @@ extern void _get_distances(double *points, int npoints, int ndim, double *distan
 
 extern double _get_kernel_size(double *distances, int npoints, double fraction)
 {
-    int i, j, o, m = 0, n = (npoints * (npoints - 1)) / 2;
+    /* npoints * (npoints - 1) overflows a 32-bit int well before npoints
+     * reaches the tens of thousands, corrupting the malloc size below
+     * (GH-6); the explicit cast forces the multiplication to happen in
+     * 64 bits. */
+    int64_t i, j, o, m = 0, n = ((int64_t) npoints * (npoints - 1)) / 2;
     double kernel_size;
     double *scratch = (double*) malloc(n * sizeof(double));
     for(i=0; i<npoints-1; ++i)
@@ -123,7 +130,7 @@ extern double _get_kernel_size(double *distances, int npoints, double fraction)
             scratch[m++] = distances[o + j];
     }
     mixed_sort(scratch, 0, n - 1);
-    kernel_size = scratch[(int) floor(0.5 + fraction * n)];
+    kernel_size = scratch[(int64_t) floor(0.5 + fraction * n)];
 
     /* kernel_size is used as a divisor, it can't be zero. Fall back to the first
      * nonzero value. Technically, they *could* all be zero (degenerate case
@@ -132,7 +139,7 @@ extern double _get_kernel_size(double *distances, int npoints, double fraction)
      */
     if(kernel_size == 0.0)
     {
-        for(int i = 0; i < n; i++)
+        for(int64_t i = 0; i < n; i++)
         {
             if(scratch[i] != 0.0)
             {
@@ -148,7 +155,7 @@ extern double _get_kernel_size(double *distances, int npoints, double fraction)
 
 extern void _get_density(double kernel_size, double *distances, int npoints, double *density)
 {
-    int i, j, o;
+    int64_t i, j, o;
     double rho;
     for(i=0; i<npoints-1; ++i)
     {
@@ -165,7 +172,7 @@ extern void _get_density(double kernel_size, double *distances, int npoints, dou
 extern void _get_delta_and_neighbour(
     double max_distance, double *distances, int *order, int npoints, double *delta, int *neighbour)
 {
-    int i, j, o;
+    int64_t i, j, o;
     double max_delta = 0.0;
     for(i=0; i<npoints; ++i)
     {
@@ -175,7 +182,7 @@ extern void _get_delta_and_neighbour(
     delta[order[0]] = -1.0;
     for(i=1; i<npoints; ++i)
     {
-        o = order[i] * npoints;
+        o = (int64_t) order[i] * npoints;
         for(j=0; j<i; ++j)
         {
             if(distances[o + order[j]] < delta[order[i]])
@@ -208,7 +215,7 @@ extern void _get_border(
     double kernel_size, double *distances, double *density, int *membership, int npoints,
     int *border_member, double *border_density)
 {
-    int i, j, o;
+    int64_t i, j, o;
     double average_density;
     for(i=0; i<npoints-1; ++i)
     {

--- a/pydpc/dpc.py
+++ b/pydpc/dpc.py
@@ -280,6 +280,12 @@ class Cluster(Graph):
             Results are stored on the instance; see the `clusters`,
             `membership`, `border_density`, `border_member`, `halo_idx`, and
             `core_idx` attributes.
+
+        Raises
+        ------
+        ValueError
+            If no point satisfies both thresholds, i.e. no cluster center
+            is found.
         """
         self.min_density = min_density
         self.min_delta = min_delta
@@ -287,6 +293,14 @@ class Cluster(Graph):
         if self.autoplot:
             self.draw_decision_graph(self.min_density, self.min_delta)
         self._get_cluster_indices()
+        if self.nclusters == 0:
+            raise ValueError(
+                f"no cluster centers found for min_density={min_density} and "
+                f"min_delta={min_delta}. Lower one or both thresholds so that "
+                "at least one point qualifies as a cluster center; passing "
+                "empty clusters to the C extension leads to undefined "
+                "behaviour (see GH-8)."
+            )
         self.membership = _core.get_membership(self.clusters, self.order, self.neighbour)
         self.border_density, self.border_member = _core.get_border(
             self.kernel_size,

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,39 @@
+# This file is part of pydpc.
+#
+# Copyright 2016-2026 Christoph Wehmeyer
+#
+# pydpc is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from pydpc import Cluster
+
+
+class TestEmptyClusters:
+    @classmethod
+    def setup_class(cls):
+        cls.npoints = 200
+        cls.points = np.random.randn(cls.npoints, 2)
+        cls.dpc = Cluster(cls.points, autoplot=False)
+
+    def test_assign_raises_instead_of_propagating_empty_clusters(self):
+        # thresholds above every point's density/delta select zero cluster
+        # centers; previously this led to undefined behaviour (and could
+        # segfault) inside the C extension instead of failing cleanly (GH-8)
+        with pytest.raises(ValueError, match="no cluster centers"):
+            self.dpc.assign(
+                min_density=self.dpc.density.max() + 1,
+                min_delta=self.dpc.delta.max() + 1,
+            )


### PR DESCRIPTION
## Summary
- Fixes #8: `Cluster.assign` could segfault when the chosen density/delta
  thresholds selected zero cluster centers. `_get_membership` would read
  `membership[-1]` (an uninitialized sentinel), propagating a garbage
  cluster index into `_get_border`/`_get_halo`. `assign` now raises a
  clear `ValueError` before ever reaching the C extension in this case.
- Fixes #6: the C extension computed flat matrix offsets (`i * npoints`)
  and a scratch-buffer size (`npoints * (npoints - 1)`) using 32-bit
  `int` arithmetic, which overflows once `npoints` exceeds roughly
  46,000 - corrupting a `malloc` size and crashing. This was reported
  as the package "shutting down" on 50,000+ points despite having 1.5TB
  of RAM available; the crash was from integer overflow, not memory
  exhaustion. Widened the affected variables to 64 bits. No public
  signature changed, so nothing on the Python/Cython side needed updating.

The integer-overflow fix here matches what @marscher correctly diagnosed back in 2020 (see #6), same root cause, widened the same variables. PR #9 wasn't merged as-is because it bundled that fix with several unrelated changes (a sort-algorithm swap, style/PEP8 changes, test tweaks), which made it hard to review independently; this is a minimal, standalone version of his original idea. PR #5 was a separate, unrelated feature proposal.